### PR TITLE
typo: "G ets" --> "Gets"

### DIFF
--- a/apidoc/MathNet.Iridium.Monodoc/iridium-docs/MathNet.Numerics/Quaternion.xml
+++ b/apidoc/MathNet.Iridium.Monodoc/iridium-docs/MathNet.Numerics/Quaternion.xml
@@ -59,8 +59,8 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>G
-            ets the standard euclidean length |q| = sqrt(||q||) of the quaternion q: the square root of the sum of the squares of the four components.
+        <summary>
+            Gets the standard euclidean length |q| = sqrt(||q||) of the quaternion q: the square root of the sum of the squares of the four components.
             Q may then be represented as q = r*(cos(phi) + u * sin(phi)) = r*exp(phi*u) where u is the unit vector and phi the argument of q.
             </summary>
         <value>To be added.</value>


### PR DESCRIPTION
Not sure why the diff shows whitespace changes; I didn't touch any other line, so this was probably due to github's editor standardizing the indentation throughout the file.

In any case, the clean diff can be seen [here](https://github.com/mathnet/mathnet-iridium/pull/4/files?w=1).